### PR TITLE
Remove the scala dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM codingame/scala-sbt:2.12
+FROM codingame/sbt:0.13.15
+
+ENV SBT_OPTS="-Xmx768M -XX:+UseConcMarkSweepGC -XX:+CMSClassUnloadingEnabled -Xss2M  -Duser.timezone=GMT"
 
 COPY build.sh      /project/build
 COPY entrypoint.sh /


### PR DESCRIPTION
Use directly the sbt image. The scala is downloading during the build with the version defined in the sbt settings file.