### PR TITLE
fix: fix the sbt test-only command line

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -6,4 +6,4 @@ echo 'CG> redirect-streams --pattern "\[error\].*" "sbt error"'
 test=${1}
 shift
 
-sbt test-only ${test} ${@}
+sbt "test-only ${test}" ${@}


### PR DESCRIPTION
Using sbt in command line, it is mandatory to use quotes so that sbt can interpret just one command.